### PR TITLE
Fix quotation marks

### DIFF
--- a/units/1_unit/03_lesson/lab.md
+++ b/units/1_unit/03_lesson/lab.md
@@ -5,11 +5,11 @@ Practice typing out some statements in the editor part of the IDE, then hit "Run
 
 | Expression | Expected Output | Did anything unexpected happen? |
 |------------|-----------------|--------|
-|`print(“1”)`|                 |        |
+|`print("1")`|                 |        |
 |`print(1)`|                   |        |
 |`print(1 + 2)`|               |        |
-|`print(“1” + “2”)`|           |        |
-|`print(“this” + “ “ + “is” + “ “ + “a” + “ “ + “sentence” + “.”)`|              |   |        |
+|`print("1" + "2")`|           |        |
+|`print("this" + " " + "is" + " " + "a" + " " + "sentence" + ".")`|              |   |        |
 
 
 ## Part 2 - Variables Practice

--- a/units/1_unit/04_lesson/do_now.md
+++ b/units/1_unit/04_lesson/do_now.md
@@ -2,10 +2,10 @@
 Type in the following code into a file and save: 
 
 ```python
-a = input(“What is your name? ”)
-# a = “cats and dogs”
+a = input("What is your name? ")
+# a = "cats and dogs"
 # meow
-print(“Hello there, ” + a)
+print("Hello there, " + a)
 ```
 
 1. Read through the code and write down what you expect the printed results to be?
@@ -27,8 +27,8 @@ Convert the following to Python code:
 Copy the following code into your editor. 
 
 ```python
-a = “this sentence should go second”
-b = “this sentence should go first.”  
+a = "this sentence should go second"
+b = "this sentence should go first."  
 c = a 
 a = b 
 # your code starts here

--- a/units/1_unit/05_lesson/quiz.md
+++ b/units/1_unit/05_lesson/quiz.md
@@ -20,19 +20,19 @@ Write down what data type you would expect to get back from the terminal (string
 3)  `x`
 <br>
 <br>
-4)  `‘ab’` 
+4)  `'ab'` 
 <br>
 <br>
-5)   `‘ab + b’`
+5)   `'ab + b'`
 <br>
 <br>
-6)  `‘ab’ + ‘b’`
+6)  `'ab' + 'b'`
 <br>
 <br>
-7)  `‘1’ * ‘b’`
+7)  `'1' * 'b'`
 <br>
 <br>
-8)  `‘a’ * 2`
+8)  `'a' * 2`
 <br>
 <br>
 What will be printed out after the code below is run? <br><br>

--- a/units/5_unit/02_lesson/lab.md
+++ b/units/5_unit/02_lesson/lab.md
@@ -8,7 +8,7 @@ a.	“0”
 b.	“+”
 
 
-c.	“-“
+c.	“-”
 
 
 2. Create a new EarSketch project using the following requirements. Include your name and a project description at the top of the file.

--- a/units/6_unit/01_lesson/associated_reading.md
+++ b/units/6_unit/01_lesson/associated_reading.md
@@ -36,7 +36,7 @@ But that’s not a problem because the elements of a dictionary are never indexe
 'dos'
 ```
 
-The key ’two’ always maps to the value 'dos' so the order of the items doesn’t matter.
+The key ‘two’ always maps to the value 'dos' so the order of the items doesn’t matter.
 If the key isn’t in the dictionary, you get an exception:
 
 ```

--- a/units/6_unit/02_lesson/associated_reading.md
+++ b/units/6_unit/02_lesson/associated_reading.md
@@ -9,7 +9,7 @@ To add items to the dictionary, you can use square brackets:
 >>> eng2sp['one'] = 'uno'
 ```
 
-This line creates an item that maps from the key ’one’ to the value 'uno'. If we print the dictionary again, we see a key-value pair with a colon between the key and value:
+This line creates an item that maps from the key ‘one’ to the value 'uno'. If we print the dictionary again, we see a key-value pair with a colon between the key and value:
 
 ```
 >>> print(eng2sp)
@@ -54,4 +54,4 @@ Here’s how it works:
 {'a': 1, 'b': 1, 'o': 2, 'n': 1, 's': 2, 'r': 2, 'u': 2, 't': 1}
 ```
 
-The histogram indicates that the letters ’a’ and 'b' appear once; 'o' appears twice, and so on.
+The histogram indicates that the letters ‘a’ and ‘b’ appear once; ‘o’ appears twice, and so on.


### PR DESCRIPTION
There were several places where "smart quotes" (aka "curly quotes") were used in Python code, which won't compile. Changed them to regular quotation marks.
