### PR TITLE
fix typo, remove some trailing whitespace

### DIFF
--- a/units/3_unit/03_lesson/lesson.md
+++ b/units/3_unit/03_lesson/lesson.md
@@ -1,7 +1,7 @@
 # Lesson 3.03: Return vs Print
 
 ##Learning Objectives
-Students will be able to... 
+Students will be able to...
 * Define and identify: **return, none, void**
 * Explain and demonstrate the difference between printing and returning
 
@@ -19,35 +19,35 @@ Students will be able to...
 | 35 Minutes | Lab         |
 | 5 Minutes | Debrief  |
 | **Day 2**  |             |
-| 10 Minutes | Recap & Review     | 
+| 10 Minutes | Recap & Review     |
 | 40 Minutes | Finish Lab  |
-| 5 Minutes | Debrief  |  
+| 5 Minutes | Debrief  |
 
 ## Instructor's Notes
 1. **Do Now**
-    * Students experiment with a function that returns a value, but they must add a print command to output that value. 
+    * Students experiment with a function that returns a value, but they must add a print command to output that value.
 2. **Lesson**
-    * Ask students about what they think the difference between returning and printing is. 
+    * Ask students about what they think the difference between returning and printing is.
         * Get a volunteer to describe how they rewrote the code in the Do Now to get a value output.
-        * Ask a student to write the code on the board. 
+        * Ask a student to write the code on the board.
     * Discuss the concept of the function contract again, explaining that the functions we will work with have both inputs and outputs.
-    * Returning is a concept in Snap!, just with a different name: reporting. 
-        * ![BJC Reporint](http://bjc.berkeley.edu/bjc-r/img/building-blocks/max-code-buggy.png) 
-    * If students appear to be struggling with the return vs. print concept, try this activity: 
-        * Students work together to build a structure using cards. One student volunteer represents the `give_card` function. This students holds the deck of cards and stands by the board. 
-        * On the board display the `give_card` function in code code that only **prints** the value of a randomly chosen card. Students 'call' the student and request cards, which then the student follows the instructions and draws ('prints') the card on the board.
-        * Next display a new `give_card` function that **returns** a card instead. Have students 'call' the function, however this time have the `give_card` student pass out the card when a student calls him/her. 
-    	* Debrief the activity and talk about what was learned. 
+    * Returning is a concept in Snap!, just with a different name: reporting.
+        * ![BJC Reporint](http://bjc.berkeley.edu/bjc-r/img/building-blocks/max-code-buggy.png)
+    * If students appear to be struggling with the return vs. print concept, try this activity:
+        * Students work together to build a structure using cards. One student volunteer represents the `give_card` function. This students holds the deck of cards and stands by the board.
+        * On the board display the `give_card` function in code that only **prints** the value of a randomly chosen card. Students 'call' the student and request cards, which then the student follows the instructions and draws ('prints') the card on the board.
+        * Next display a new `give_card` function that **returns** a card instead. Have students 'call' the function, however this time have the `give_card` student pass out the card when a student calls him/her.
+    	* Debrief the activity and talk about what was learned.
 3. **Lab**
-    * Given a shuffled deck list, students will create a program that plays the game 'War' with the user. 
-    
+    * Given a shuffled deck list, students will create a program that plays the game 'War' with the user.
+
 4. **Debrief**
     * Check student progress and completion of the lab, wrap up by taking any final questions.
 
 
 ###Accommodation/Differentiation
 As an extension activity, ask students to research the shuffle function and the functions associated with it.
-  
+
 
 [Do Now]:do_now.md
 [Lab - War (Card Game)]:lab.md


### PR DESCRIPTION
My editor removes trailing whitespace on save. If this is a problem, I can change the commit to only include the typo fix.
