### PR TITLE
Convert tabs to spaces

### DIFF
--- a/units/7_unit/03_lesson/lesson.md
+++ b/units/7_unit/03_lesson/lesson.md
@@ -36,7 +36,7 @@ Students will be able to...
 		* **`__str__`**: Need a method called `__str__`. This will get called when you print an object, and it returns a string that is easy to read and understand.
 			* Have the students practice writing `__str__` for the `Time` class for 5 minutes.
 			* Have a student write up their string method on the board. 
-		* **`__add__`**: add is another method that gets called when the plus sign is used. In this case it takes in another two time objects and returns a time object that is the sum of both. 
+		* **`__add__`**: add is a method that gets called when the plus sign is used between two `Time` objects. In this case it takes as parameters `self` and another `Time` object and returns a `Time` object that is the sum of both.
 			* Overwriting add is called **operator overloading** because you are re-writing the code used to make the + work.
 			* Work together with students to come up with the add time algorithm.
 3. **Lab**	

--- a/units/7_unit/04_lesson/example.py
+++ b/units/7_unit/04_lesson/example.py
@@ -1,18 +1,18 @@
 import random
 
 class Pokemon(object):
-	def __init__(self, name, health_points, attack_power_upper_range, attack_power_lower_range):
-		self.name = name
-		self.health_points = health_points
-		self.attack_power_lower_range = attack_power_lower_range
-		self.attack_power_upper_range = attack_power_upper_range
+    def __init__(self, name, health_points, attack_power_upper_range, attack_power_lower_range):
+        self.name = name
+        self.health_points = health_points
+        self.attack_power_lower_range = attack_power_lower_range
+        self.attack_power_upper_range = attack_power_upper_range
 
-	def attack(self):
-		return  random.randint(self.attack_power_lower_range, self.attack_power_upper_range)
+    def attack(self):
+        return  random.randint(self.attack_power_lower_range, self.attack_power_upper_range)
 
-	def defend(self, enemy, attack_power):
-		self.health_points -= attack_power
+    def defend(self, enemy, attack_power):
+        self.health_points -= attack_power
 
-	def growl(self):
-		print("Growl")
+    def growl(self):
+        print("Growl")
 


### PR DESCRIPTION
Cloud9 uses 4 spaces by default.
If students copy and paste from a file with tabs into the editor, their file will have a mix of tabs and spaces.
Python will complain if they are mixed on the same line, which can happen as you edit and move stuff around.
So let's make it easy for them.
