### PR TITLE
Fix bug where param name did not match use in body

### DIFF
--- a/readings.md
+++ b/readings.md
@@ -1806,7 +1806,7 @@ By convention, the first parameter of a method is called self, so it would be mo
 ```
 class Time(object):
     def print_time(self):
-    	print(str(time.hour) + ":" + str(time.minute) + ":" + str(time.second))
+    	print(str(self.hour) + ":" + str(self.minute) + ":" + str(self.second))
 ```
 
 The reason for this convention is an implicit metaphor:


### PR DESCRIPTION
The parameter name was "self", but in the body of the method, it was called "time". I changed the instances of "time" to "self" to make it correct. This was probably a copy and paste error.